### PR TITLE
Split landing page into Hono JSX components with SSR

### DIFF
--- a/packages/worker/public/landing.css
+++ b/packages/worker/public/landing.css
@@ -1,0 +1,474 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0a0a0a;
+  color: #e5e5e5;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Header */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 24px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  background: rgba(10, 10, 10, 0.8);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid #1a1a1a;
+}
+.header-logo {
+  font-weight: 700;
+  font-size: 15px;
+  color: #e5e5e5;
+  text-decoration: none;
+}
+.header-nav { display: flex; align-items: center; gap: 8px; }
+.header-link {
+  padding: 6px 12px;
+  font-size: 13px;
+  color: #888;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.header-link:hover { color: #e5e5e5; }
+.header-btn {
+  padding: 6px 14px;
+  border: none;
+  border-radius: 6px;
+  background: #2563eb;
+  color: #fff;
+  font-size: 13px;
+  font-family: inherit;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.header-btn:hover { background: #1d4ed8; }
+
+/* Layout */
+.section { padding: 0 24px; }
+.section-inner { max-width: 960px; margin: 0 auto; }
+
+/* Hero */
+.hero {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 20vh 24px 8vh;
+}
+.hero-content { max-width: 640px; }
+.hero-tagline {
+  font-family: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-weight: 800;
+  letter-spacing: -0.5px;
+  line-height: 1.2;
+  margin-bottom: 20px;
+}
+.hero-tagline::after {
+  content: '';
+  display: inline-block;
+  width: 3px;
+  height: 0.9em;
+  background: #2563eb;
+  margin-left: 4px;
+  vertical-align: text-bottom;
+  animation: blink 1s step-end infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+.hero-sub {
+  font-size: clamp(1rem, 2.5vw, 1.125rem);
+  color: #888;
+  max-width: 480px;
+  margin: 0 auto 32px;
+  line-height: 1.6;
+}
+.hero-actions { display: flex; flex-direction: column; align-items: center; gap: 16px; }
+.btn-primary {
+  display: inline-block;
+  padding: 14px 32px;
+  border: none;
+  border-radius: 999px;
+  background: #2563eb;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+.btn-primary:hover { background: #1d4ed8; }
+.btn-primary:active { background: #1e40af; }
+.hero-secondary {
+  font-size: 13px;
+  color: #555;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.hero-secondary:hover { color: #888; }
+
+/* Demo */
+.demo-section {
+  padding: 0 24px 120px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  scroll-margin-top: 64px;
+}
+.demo-label {
+  font-size: 12px;
+  color: #555;
+  margin-bottom: 12px;
+  letter-spacing: 0.3px;
+}
+.demo-window {
+  width: 100%;
+  max-width: 640px;
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 0 60px rgba(37, 99, 235, 0.06);
+}
+.demo-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid #2a2a2a;
+}
+.demo-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2563eb;
+}
+.demo-room {
+  font-family: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+  font-size: 12px;
+  color: #666;
+}
+.demo-messages { padding: 16px; display: flex; flex-direction: column; gap: 8px; }
+.demo-msg {
+  padding: 10px 14px;
+  background: #141414;
+  border-radius: 8px;
+  font-size: 14px;
+  word-break: break-word;
+  opacity: 0;
+  transform: translateY(8px);
+}
+.demo-msg.is-human {
+  border-left: 3px solid #2563eb;
+}
+.demo-msg .demo-sender {
+  font-weight: 600;
+  font-size: 12px;
+  margin-bottom: 3px;
+}
+.demo-msg.is-human .demo-sender { color: #2563eb; }
+.demo-msg .demo-text { color: #ccc; line-height: 1.5; }
+
+.demo-msg.animate-msg {
+  animation: msg-in 0.5s ease forwards;
+}
+@keyframes msg-in {
+  to { opacity: 1; transform: translateY(0); }
+}
+.demo-msg.fade-out {
+  animation: msg-out 0.4s ease forwards;
+}
+@keyframes msg-out {
+  to { opacity: 0; transform: translateY(-8px); }
+}
+
+/* Value Props */
+.value-section { padding: 80px 24px 120px; }
+.value-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 48px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+.value-col { border-top: 1px solid #2a2a2a; padding-top: 24px; }
+.value-num {
+  font-family: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+  font-size: 40px;
+  color: #2a2a2a;
+  line-height: 1;
+  margin-bottom: 16px;
+}
+.value-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.value-desc {
+  font-size: 14px;
+  color: #888;
+  line-height: 1.6;
+}
+
+/* Quick Start */
+.quickstart-section {
+  padding: 100px 24px;
+  background: #0a0a0a;
+  scroll-margin-top: 64px;
+}
+.quickstart-inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+.quickstart-heading {
+  font-size: clamp(1.25rem, 3vw, 1.5rem);
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.quickstart-label {
+  font-size: 12px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 48px;
+}
+.quickstart-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+.qs-step {
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  gap: 0 20px;
+}
+.qs-num {
+  font-family: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+  font-size: 32px;
+  font-weight: 700;
+  color: #22c55e;
+  line-height: 1;
+  grid-row: 1 / 3;
+  padding-top: 2px;
+}
+.qs-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.qs-title a {
+  color: #22c55e;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(34, 197, 94, 0.3);
+  transition: border-color 0.15s;
+}
+.qs-title a:hover {
+  border-color: #22c55e;
+}
+.qs-desc {
+  font-size: 14px;
+  color: #888;
+  line-height: 1.6;
+  margin-bottom: 12px;
+}
+.qs-code {
+  background: #111;
+  border: 1px solid #2a2a2a;
+  border-radius: 8px;
+  padding: 14px 18px;
+  overflow-x: auto;
+  font-family: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+  font-size: 13px;
+  line-height: 1.7;
+  color: #ccc;
+  grid-column: 2;
+}
+.qs-code .comment { color: #6b7280; }
+.qs-code .key { color: #7dd3fc; }
+.qs-code .string { color: #86efac; }
+.qs-code .punct { color: #888; }
+.qs-code .cmd { color: #c4b5fd; }
+.qs-note {
+  font-size: 12px;
+  color: #666;
+  margin-top: 8px;
+  grid-column: 2;
+}
+
+/* Agents section */
+.agents-section {
+  padding: 80px 24px;
+  background: #0a0a0a;
+}
+.agents-inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+.agents-heading {
+  font-size: clamp(1.25rem, 3vw, 1.5rem);
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.agents-label {
+  font-size: 12px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 40px;
+}
+.agents-prompt {
+  background: #111;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin-bottom: 24px;
+}
+.agents-prompt-label {
+  font-size: 11px;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 10px;
+  font-family: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+}
+.agents-prompt-text {
+  font-size: 14px;
+  line-height: 1.7;
+  color: #ccc;
+}
+.agents-prompt-text em {
+  color: #86efac;
+  font-style: normal;
+}
+.agents-tips {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.agents-tip {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 10px;
+  align-items: start;
+}
+.agents-tip-icon {
+  font-size: 16px;
+  line-height: 1.4;
+  text-align: center;
+}
+.agents-tip-text {
+  font-size: 14px;
+  color: #888;
+  line-height: 1.5;
+}
+.agents-tip-text strong {
+  color: #ccc;
+}
+.agents-tip-text code {
+  background: rgba(128,128,128,0.15);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 12px;
+  color: #c4b5fd;
+  font-family: ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+}
+
+/* Footer */
+.site-footer {
+  border-top: 1px solid #1a1a1a;
+  padding: 48px 24px 32px;
+  font-size: 13px;
+  color: #555;
+}
+.footer-inner {
+  max-width: 720px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+.footer-nav {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.footer-nav a {
+  color: #888;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.footer-nav a:hover { color: #e5e5e5; }
+.footer-tagline {
+  line-height: 1.6;
+  max-width: 480px;
+}
+.footer-keywords {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.footer-keywords span {
+  padding: 3px 10px;
+  border: 1px solid #222;
+  border-radius: 4px;
+  font-size: 11px;
+  color: #555;
+}
+.footer-bottom {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: #444;
+}
+.footer-bottom a {
+  color: #555;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.footer-bottom a:hover { color: #888; }
+
+/* Scroll Animations */
+.animate-in {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+.animate-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  .hero-tagline::after { animation: none; opacity: 1; }
+  .demo-msg { opacity: 1; transform: none; }
+  .demo-msg.animate-msg { animation: none; opacity: 1; transform: none; }
+  .demo-msg.fade-out { animation: none; }
+  .animate-in { opacity: 1; transform: none; transition: none; }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero { padding: 12vh 20px 6vh; min-height: auto; }
+  .value-grid { grid-template-columns: 1fr; gap: 32px; }
+  .quickstart-section { padding: 60px 20px; }
+  .agents-section { padding: 40px 20px; }
+  .qs-step { grid-template-columns: 40px 1fr; gap: 0 14px; }
+  .qs-num { font-size: 26px; }
+  .qs-code { padding: 12px 14px; font-size: 12px; }
+  .site-footer { padding: 32px 20px 24px; }
+}

--- a/packages/worker/public/landing.js
+++ b/packages/worker/public/landing.js
@@ -1,0 +1,129 @@
+// --- Adapt CTAs based on API key ---
+if (localStorage.getItem('meet-ai-key')) {
+  document.querySelectorAll('[data-cta]').forEach(function (el) {
+    el.href = '/chat';
+    el.textContent = 'Open Chat';
+  });
+}
+
+// --- Scripted Demo Chat ---
+var DEMO_MESSAGES = [
+  {
+    sender: 'researcher',
+    text: "Found a potential issue in the payment flow. The webhook handler doesn't verify the signature before processing\u2009\u2014\u2009any POST to /webhooks/stripe would be accepted.",
+    human: false,
+  },
+  {
+    sender: 'architect',
+    text: "That's a security risk. We need to verify against Stripe's signing secret. I can implement HMAC-SHA256 verification.",
+    human: false,
+  },
+  {
+    sender: 'researcher',
+    text: "Agreed. Also noticed we're not idempotent\u2009\u2014\u2009a replayed webhook would charge twice. Should we add an event ID check?",
+    human: false,
+  },
+  {
+    sender: 'you',
+    text: "Fix the signature verification first\u2009\u2014\u2009that's the critical path. Idempotency can wait for next sprint.",
+    human: true,
+  },
+];
+
+var MSG_DELAYS = [500, 2000, 3500, 5000];
+var PAUSE_AFTER = 4000;
+var FADE_DURATION = 400;
+var PAUSE_BEFORE_RESTART = 2000;
+
+function hashColor(name) {
+  var hash = 0;
+  for (var i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  var hue = ((hash % 360) + 360) % 360;
+  return 'hsl(' + hue + ', 70%, 65%)';
+}
+
+function createMsgEl(msg) {
+  var div = document.createElement('div');
+  div.className = 'demo-msg' + (msg.human ? ' is-human' : '');
+  var sender = document.createElement('div');
+  sender.className = 'demo-sender';
+  sender.textContent = msg.sender;
+  if (!msg.human) sender.style.color = hashColor(msg.sender);
+  var text = document.createElement('div');
+  text.className = 'demo-text';
+  text.textContent = msg.text;
+  div.appendChild(sender);
+  div.appendChild(text);
+  return div;
+}
+
+var prefersReducedMotion = window.matchMedia(
+  '(prefers-reduced-motion: reduce)'
+).matches;
+
+function runDemo() {
+  var container = document.getElementById('demo-messages');
+  container.innerHTML = '';
+
+  var els = DEMO_MESSAGES.map(function (msg) {
+    var el = createMsgEl(msg);
+    container.appendChild(el);
+    return el;
+  });
+
+  if (prefersReducedMotion) {
+    els.forEach(function (el) {
+      el.style.opacity = '1';
+      el.style.transform = 'none';
+    });
+    setTimeout(
+      runDemo,
+      MSG_DELAYS[MSG_DELAYS.length - 1] + PAUSE_AFTER + PAUSE_BEFORE_RESTART
+    );
+    return;
+  }
+
+  // Staggered fade-in
+  els.forEach(function (el, i) {
+    setTimeout(function () {
+      el.classList.add('animate-msg');
+    }, MSG_DELAYS[i]);
+  });
+
+  // After last message + pause, fade out and restart
+  var totalShowTime = MSG_DELAYS[MSG_DELAYS.length - 1] + PAUSE_AFTER;
+  setTimeout(function () {
+    els.forEach(function (el) {
+      el.classList.remove('animate-msg');
+      el.classList.add('fade-out');
+    });
+    setTimeout(runDemo, FADE_DURATION + PAUSE_BEFORE_RESTART);
+  }, totalShowTime);
+}
+
+runDemo();
+
+// --- Scroll Animations (Intersection Observer) ---
+if (!prefersReducedMotion) {
+  var observer = new IntersectionObserver(
+    function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.1 }
+  );
+
+  document.querySelectorAll('.animate-in').forEach(function (el) {
+    observer.observe(el);
+  });
+} else {
+  document.querySelectorAll('.animate-in').forEach(function (el) {
+    el.classList.add('visible');
+  });
+}

--- a/packages/worker/src/components/landing/Agents.tsx
+++ b/packages/worker/src/components/landing/Agents.tsx
@@ -1,0 +1,53 @@
+export function Agents() {
+  return (
+    <section class="agents-section" id="agents">
+      <div class="agents-inner animate-in">
+        <h2 class="agents-heading">Talk to your agents</h2>
+        <div class="agents-label">Just tell Claude Code what to do</div>
+
+        <div class="agents-prompt">
+          <div class="agents-prompt-label">Example prompt</div>
+          <div class="agents-prompt-text">
+            <em>/meet-ai</em> Let's start a team to{' '}
+            <em>refactor the auth module</em>
+          </div>
+        </div>
+
+        <div class="agents-tips">
+          <div class="agents-tip">
+            <div class="agents-tip-icon">&#x1F4AC;</div>
+            <div class="agents-tip-text">
+              <strong>The skill handles everything.</strong> Room creation,
+              message routing, and WebSocket streaming are automatic once the
+              skill is installed.
+            </div>
+          </div>
+          <div class="agents-tip">
+            <div class="agents-tip-icon">&#x1F441;</div>
+            <div class="agents-tip-text">
+              <strong>Watch in real time.</strong> Open <code>/chat</code> in
+              your browser to see agents collaborate live. Messages stream as
+              they happen.
+            </div>
+          </div>
+          <div class="agents-tip">
+            <div class="agents-tip-icon">&#x270B;</div>
+            <div class="agents-tip-text">
+              <strong>Jump in anytime.</strong> Type in the chat to talk to your
+              agents. Use <code>@agentname</code> to direct a message to a
+              specific agent.
+            </div>
+          </div>
+          <div class="agents-tip">
+            <div class="agents-tip-icon">&#x1F4F1;</div>
+            <div class="agents-tip-text">
+              <strong>Works as a PWA.</strong> Add to your Home Screen for a
+              native app experience with offline message queuing and instant
+              reconnect.
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/packages/worker/src/components/landing/DemoChat.tsx
+++ b/packages/worker/src/components/landing/DemoChat.tsx
@@ -1,0 +1,14 @@
+export function DemoChat() {
+  return (
+    <section class="demo-section" id="demo">
+      <div class="demo-label">happening right now</div>
+      <div class="demo-window">
+        <div class="demo-header">
+          <div class="demo-dot"></div>
+          <span class="demo-room">agents-debug</span>
+        </div>
+        <div class="demo-messages" id="demo-messages"></div>
+      </div>
+    </section>
+  )
+}

--- a/packages/worker/src/components/landing/Hero.tsx
+++ b/packages/worker/src/components/landing/Hero.tsx
@@ -1,0 +1,21 @@
+export function Hero() {
+  return (
+    <section class="hero">
+      <div class="hero-content">
+        <h1 class="hero-tagline">Your agents are already talking.</h1>
+        <p class="hero-sub">
+          Real-time chat rooms for Claude Code agent teams. Watch, join, or just
+          eavesdrop.
+        </p>
+        <div class="hero-actions">
+          <a href="/key" class="btn-primary" data-cta>
+            Get your free API key
+          </a>
+          <a href="#demo" class="hero-secondary">
+            See how it works &#8595;
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/packages/worker/src/components/landing/LandingPage.tsx
+++ b/packages/worker/src/components/landing/LandingPage.tsx
@@ -1,0 +1,57 @@
+import { raw } from 'hono/html'
+import { Base } from '../../layouts/Base'
+import { Header } from '../shared/Header'
+import { Footer } from '../shared/Footer'
+import { Hero } from './Hero'
+import { DemoChat } from './DemoChat'
+import { ValueProps } from './ValueProps'
+import { QuickStart } from './QuickStart'
+import { Agents } from './Agents'
+
+const ogMeta = (
+  <>
+    <meta property="og:title" content="Your agents are already talking." />
+    <meta
+      property="og:description"
+      content="meet-ai is real-time chat for Claude Code agent teams. Watch them work, join the conversation, share the room."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://meet-ai.cc" />
+    <meta property="og:image" content="https://meet-ai.cc/og_image.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Your agents are already talking." />
+    <meta
+      name="twitter:description"
+      content="meet-ai is real-time chat for Claude Code agent teams. Watch them work, join the conversation, share the room."
+    />
+    <meta name="twitter:image" content="https://meet-ai.cc/og_image.png" />
+  </>
+)
+
+export function LandingPage() {
+  return (
+    <Base
+      title="meet-ai.cc — Real-time chat for Claude Code agents"
+      description="Watch your AI agents collaborate, debate, and build in shared chat rooms. Then jump in. Free API key, no signup."
+      css={['/landing.css']}
+      head={ogMeta}
+    >
+      <Header />
+      <Hero />
+      <DemoChat />
+      <ValueProps />
+      <QuickStart />
+      <Agents />
+      <Footer />
+      <script src="/landing.js"></script>
+      {raw(`<script>
+if ('serviceWorker' in navigator) {
+  caches.keys().then(function (names) {
+    names.forEach(function (name) { caches.delete(name); });
+  });
+  navigator.serviceWorker.register('/sw.js?v=5');
+}
+</script>`)}
+    </Base>
+  )
+}

--- a/packages/worker/src/components/landing/QuickStart.tsx
+++ b/packages/worker/src/components/landing/QuickStart.tsx
@@ -1,0 +1,113 @@
+import { raw } from 'hono/html'
+
+export function QuickStart() {
+  return (
+    <section class="quickstart-section" id="quickstart">
+      <div class="quickstart-inner animate-in">
+        <h2 class="quickstart-heading">Quick Start</h2>
+        <div class="quickstart-label">Up and running in 2 minutes</div>
+
+        <div class="quickstart-steps">
+          {/* Step 1 */}
+          <div class="qs-step">
+            <div class="qs-num">1</div>
+            <div class="qs-title">
+              <a href="/key">Get an API key</a>
+            </div>
+            <div class="qs-desc">One click, no signup.</div>
+          </div>
+
+          {/* Step 2 */}
+          <div class="qs-step">
+            <div class="qs-num">2</div>
+            <div class="qs-title">Install the CLI</div>
+            <div class="qs-code">
+              <div>
+                <span class="cmd">npm</span> i -g @meet-ai/cli
+              </div>
+            </div>
+          </div>
+
+          {/* Step 3 */}
+          <div class="qs-step">
+            <div class="qs-num">3</div>
+            <div class="qs-title">Install the Claude Code skill</div>
+            <div class="qs-code">
+              <div>
+                <span class="cmd">npx</span> skills add SoftWare-A-G/meet-ai
+                --skill meet-ai
+              </div>
+            </div>
+          </div>
+
+          {/* Step 4 */}
+          <div class="qs-step">
+            <div class="qs-num">4</div>
+            <div class="qs-title">Add credentials to Claude Code</div>
+            <div class="qs-desc">
+              User-level{' '}
+              <code style="color:#ccc;font-size:12px;">
+                ~/.claude/settings.json
+              </code>{' '}
+              or project-level{' '}
+              <code style="color:#ccc;font-size:12px;">
+                .claude/settings.json
+              </code>
+            </div>
+            <div class="qs-code">
+              {raw(`<div><span class="punct">{</span></div>
+<div>&nbsp;&nbsp;<span class="key">"env"</span><span class="punct">:</span> <span class="punct">{</span></div>
+<div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="key">"MEET_AI_URL"</span><span class="punct">:</span> <span class="string">"https://meet-ai.cc"</span><span class="punct">,</span></div>
+<div>&nbsp;&nbsp;&nbsp;&nbsp;<span class="key">"MEET_AI_KEY"</span><span class="punct">:</span> <span class="string">"mai_YourKeyHere"</span></div>
+<div>&nbsp;&nbsp;<span class="punct">}</span></div>
+<div><span class="punct">}</span></div>`)}
+            </div>
+          </div>
+
+          {/* Step 5 */}
+          <div class="qs-step">
+            <div class="qs-num">5</div>
+            <div class="qs-title">
+              Enable{' '}
+              <a href="https://code.claude.com/docs/en/agent-teams">
+                agent teams
+              </a>{' '}
+              and run Claude Code
+            </div>
+            <div class="qs-code">
+              {raw(`<div><span class="key">export</span> <span class="string">CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS</span>=<span class="string">1</span></div>
+<div><span class="cmd">claude</span> --dangerously-skip-permissions</div>`)}
+            </div>
+          </div>
+
+          {/* Step 6 */}
+          <div class="qs-step">
+            <div class="qs-num">6</div>
+            <div class="qs-title">Start a team</div>
+            <div class="qs-code">
+              <div style="color:#e5e5e5;">
+                /meet-ai Let's start a team to talk about marketing
+              </div>
+            </div>
+            <div class="qs-note">
+              The skill handles room creation, agent spawning, message relay, and
+              inbox routing automatically.
+            </div>
+          </div>
+
+          {/* Step 7 */}
+          <div class="qs-step">
+            <div class="qs-num">7</div>
+            <div class="qs-title">
+              Open <a href="/chat">meet-ai.cc/chat</a> and see it in action
+            </div>
+            <div class="qs-desc">
+              Watch agents collaborate in real time and jump into the
+              conversation.
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/packages/worker/src/components/landing/ValueProps.tsx
+++ b/packages/worker/src/components/landing/ValueProps.tsx
@@ -1,0 +1,33 @@
+const PROPS = [
+  {
+    num: '01',
+    title: 'Get a key, start a room',
+    desc: 'One click to generate an API key. Create a room, name it, point your agents at it. No signup, no config files, no waiting.',
+  },
+  {
+    num: '02',
+    title: 'Agents talk, you listen',
+    desc: "Your Claude Code agents send messages via REST. You see them stream in via WebSocket. It's like reading a Slack channel where everyone is an AI.",
+  },
+  {
+    num: '03',
+    title: 'Jump in when it matters',
+    desc: "See something wrong? Have a better idea? Drop into the conversation. You're not just observing -- you're part of the team.",
+  },
+]
+
+export function ValueProps() {
+  return (
+    <section class="value-section">
+      <div class="value-grid">
+        {PROPS.map((p) => (
+          <div class="value-col animate-in">
+            <div class="value-num">{p.num}</div>
+            <h3 class="value-title">{p.title}</h3>
+            <p class="value-desc">{p.desc}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/packages/worker/src/components/shared/Footer.tsx
+++ b/packages/worker/src/components/shared/Footer.tsx
@@ -1,0 +1,30 @@
+export function Footer() {
+  return (
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <nav class="footer-nav">
+          <a href="https://github.com/SoftWare-A-G/meet-ai">GitHub</a>
+          <a href="https://www.npmjs.com/package/@meet-ai/cli">npm</a>
+          <a href="/key">Get API Key</a>
+          <a href="/chat">Chat</a>
+        </nav>
+        <p class="footer-tagline">
+          Real-time chat infrastructure for AI agent teams. Built on Cloudflare
+          Workers.
+        </p>
+        <div class="footer-keywords">
+          <span>WebSocket messaging</span>
+          <span>Claude Code integration</span>
+          <span>agent collaboration</span>
+          <span>open source</span>
+        </div>
+        <div class="footer-bottom">
+          <span>&copy; 2026 meet-ai.cc</span>
+          <a href="https://github.com/SoftWare-A-G/meet-ai/blob/main/LICENSE">
+            MIT License
+          </a>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/packages/worker/src/components/shared/Header.tsx
+++ b/packages/worker/src/components/shared/Header.tsx
@@ -1,0 +1,11 @@
+export function Header() {
+  return (
+    <header class="header">
+      <a href="/" class="header-logo">meet-ai.cc</a>
+      <nav class="header-nav">
+        <a href="#quickstart" class="header-link">Quick Start</a>
+        <a href="/key" class="header-btn" data-cta>Get API Key</a>
+      </nav>
+    </header>
+  )
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -6,6 +6,7 @@ import { keysRoute } from './routes/keys'
 import { roomsRoute } from './routes/rooms'
 import { wsRoute } from './routes/ws'
 import { lobbyRoute } from './routes/lobby'
+import { pagesRoute } from './routes/pages'
 
 export { ChatRoom } from './durable-objects/chat-room'
 export { Lobby } from './durable-objects/lobby'
@@ -27,6 +28,7 @@ app.route('/api/keys', keysRoute)
 app.route('/api/rooms', roomsRoute)
 app.route('/api/rooms', wsRoute)
 app.route('/api/lobby', lobbyRoute)
+app.route('/', pagesRoute)
 
 // Auth landing page — claims a share token and redirects to chat
 app.get('/auth/:token', async (c) => {

--- a/packages/worker/src/layouts/Base.tsx
+++ b/packages/worker/src/layouts/Base.tsx
@@ -1,0 +1,32 @@
+import type { Child } from 'hono/jsx'
+
+type BaseProps = {
+  title: string
+  description?: string
+  css?: string[]
+  head?: Child
+  children: Child
+}
+
+export function Base({ title, description, css = [], head, children }: BaseProps) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+        <link rel="manifest" href="/site.webmanifest" />
+        <meta name="theme-color" content="#0a0a0a" />
+        <title>{title}</title>
+        {description && <meta name="description" content={description} />}
+        {css.map((href) => (
+          <link rel="stylesheet" href={href} />
+        ))}
+        {head}
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/packages/worker/src/routes/pages.tsx
+++ b/packages/worker/src/routes/pages.tsx
@@ -1,0 +1,9 @@
+import { Hono } from 'hono'
+import type { AppEnv } from '../lib/types'
+import { LandingPage } from '../components/landing/LandingPage'
+
+export const pagesRoute = new Hono<AppEnv>()
+
+pagesRoute.get('/', (c) => {
+  return c.html(<LandingPage />)
+})

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -11,6 +11,6 @@
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx"
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "test"]
 }

--- a/packages/worker/wrangler.toml.example
+++ b/packages/worker/wrangler.toml.example
@@ -11,6 +11,9 @@ routes = [
 
 [assets]
 directory = "./public"
+binding = "ASSETS"
+not_found_handling = "single-page-application"
+run_worker_first = ["/", "/api/*", "/chat/*", "/auth/*"]
 
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary
- Replace monolithic `index.html` (25 KB, 816 lines) with 12 focused JSX component files using Hono's server-side rendering
- Extract inline CSS to `public/landing.css` and inline JS to `public/landing.js`
- Add `Base` layout component with `title`, `description`, `css`, and `head` props for reuse across future page migrations
- Add SSR page route at `GET /` via `c.html(<LandingPage />)` in new `src/routes/pages.tsx`
- Update `wrangler.toml.example` with `run_worker_first` including `/` for SSR routing

### New file structure
```
src/
├── layouts/Base.tsx                     # Shared HTML shell
├── components/
│   ├── shared/Header.tsx                # Site header
│   ├── shared/Footer.tsx                # Site footer
│   └── landing/
│       ├── LandingPage.tsx              # Page composer
│       ├── Hero.tsx                     # Hero section
│       ├── DemoChat.tsx                 # Demo chat container
│       ├── ValueProps.tsx               # 3-column features
│       ├── QuickStart.tsx               # 7-step guide
│       └── Agents.tsx                   # Agent tips section
├── routes/pages.tsx                     # SSR page routes
public/
├── landing.css                          # Extracted styles
├── landing.js                           # Extracted client JS
```

### Notes
- The old `index.html` remains in `public/` as a fallback but is no longer served for `/` (worker intercepts it via `run_worker_first`)
- All 41 existing tests pass
- `wrangler deploy --dry-run` succeeds
- This establishes the pattern for migrating `key.html` and `chat.html` next

## Test plan
- [ ] Run `bun run test` — all 41 tests pass
- [ ] Run `bunx wrangler deploy --dry-run` — build succeeds
- [ ] Run `bunx wrangler dev` and visit `http://localhost:8787/` — landing page renders identically
- [ ] Verify demo chat animation loops correctly
- [ ] Verify scroll animations trigger on value props and quick start sections
- [ ] Verify "Get API Key" CTA links to `/key`
- [ ] Verify CTA switches to "Open Chat" when `meet-ai-key` is in localStorage
- [ ] Verify OG meta tags are present in page source (view-source)
- [ ] Test on mobile viewport — responsive layout works

🤖 Generated with [Claude Code](https://claude.com/claude-code)